### PR TITLE
[Ticket] Create a GraphQL server using typedefs and query resolvers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,67 @@
+import { GraphQLServer } from 'graphql-yoga'
+
+// Scalar types - String, Boolean, Int, Float, ID
+
+// Type definitions (schema)
+const typeDefs = `
+    type Query {
+        greeting(name: String, position: String): String!
+        add(a: Float!, b: Float!): Float!
+        me: User!
+        post: Post!
+    }
+
+    type User {
+        id: ID!
+        name: String!
+        email: String!
+        age: Int
+    }
+
+    type Post {
+        id: ID!
+        title: String!
+        body: String!
+        published: Boolean!
+    }
+`
+
+// Resolvers
+const resolvers = {
+    Query: {
+        greeting(parent, args, ctx, info) {
+            if (args.name && args.position) {
+                return `Hello, ${args.name}! You are my favoriate ${args.position}.`
+            } else {
+                return 'Hello!'
+            }
+        },
+        add(parent, args, ctx, info) {
+            return args.a + args.b
+        },
+        me() {
+            return {
+                id: '123098',
+                name: 'Mike',
+                email: 'mike@example.com'
+            }
+        },
+        post() {
+            return {
+                id: '092',
+                title: 'GraphQL 101',
+                body: '',
+                published: false
+            }
+        }
+    }
+}
+
+const server = new GraphQLServer({
+    typeDefs,
+    resolvers
+})
+
+server.start(() => {
+    console.log('The server is up!')
+})


### PR DESCRIPTION
## Snapshot
![2020-10-13 22 07 41](https://user-images.githubusercontent.com/7454154/95917034-84922c80-0da1-11eb-9c52-eeba905fcf86.gif)

## Description
- This GraphQL node server is setup with babel and nodemon for a smoother development experience with live refresh and using one of the latest ES syntaxes.
- I am using typedefs and query resolvers to access the server API and retrieve static data (no data base is setup at this stage yet)